### PR TITLE
implement better handling when bulk metadata cache query fails 

### DIFF
--- a/src/masschange/api/routers/missions.py
+++ b/src/masschange/api/routers/missions.py
@@ -24,7 +24,11 @@ def get_available_data_products_for_mission(mission_id: str):
                             detail=f'No mission found with id {mission_id} in extant missions ({sorted(mission.id for mission in available_missions)})')
 
     # use metadata cache to enable population of datasets with full metadata
-    bulk_metadata_cache = BulkMetadataCache()
+    try:
+        bulk_metadata_cache = BulkMetadataCache()
+    except Exception as err:
+        raise HTTPException(status_code=500, detail='API failed to resolve bulk metadata cache - please contact developer')
+
     mission_data_products = [p for p in get_dataproducts() if p.mission.id == mission_id]
     return {'data': [product.describe(metadata_cache=bulk_metadata_cache) for product in
                      sorted(mission_data_products, key=lambda product: product.id_suffix)]}

--- a/src/masschange/api/utils/db/queries.py
+++ b/src/masschange/api/utils/db/queries.py
@@ -59,8 +59,8 @@ def fetch_bulk_channel_id_enums() -> Dict[DataProduct, Dict[DataProductField, Co
             cur.execute(sql)
             result_rows = cur.fetchall()
         except Exception as err:
-            logging.warning(f'query failed with {err}: {sql}')
-            return None
+            logging.error(f'query failed with {err}: {sql}')
+            raise err
 
     results = {}
     # Initialise the results structure - this is necessary to ensure null-sets are created for products with no ingested


### PR DESCRIPTION
(due to ensure not having been run) - this now constitutes a fatal failure when making requests to the API but is less confusing.