### PR TITLE
Mission label attribute

### DIFF
--- a/src/masschange/api/routers/missions.py
+++ b/src/masschange/api/routers/missions.py
@@ -5,16 +5,16 @@ from fastapi import APIRouter, HTTPException
 
 from masschange.dataproducts.utils import get_dataproduct_classes, get_dataproducts
 from masschange.db.metadata.cache import BulkMetadataCache
-from masschange.missions import Mission
+from masschange.missions import Missions
 
-available_missions: Iterable[Type[Mission]] = {dataset.mission for dataset in get_dataproduct_classes()}
+available_missions: Iterable[Missions] = {dataset.mission for dataset in get_dataproduct_classes()}
 
 router = APIRouter()
 
 
 @router.get('/', tags=['missions', 'metadata'])
 def get_available_missions():
-    return {'data': sorted([mission.id for mission in available_missions])}
+    return {'data': [mission.asdict() for mission in sorted(available_missions, key=lambda m: m.id)]}
 
 
 @router.get('/{mission_id}/products', tags=['missions', 'metadata'])

--- a/src/masschange/dataproducts/dataproduct.py
+++ b/src/masschange/dataproducts/dataproduct.py
@@ -7,7 +7,7 @@ from typing import Set, Type, Dict, Collection, Union, Mapping
 
 import psycopg2
 
-from masschange.missions import Mission
+from masschange.missions import Mission, Missions
 from masschange.dataproducts.dataproductfield import DataProductField, \
     TimeSeriesDataProductTimestampField, TimeSeriesDataProductLocationLookupField
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
@@ -22,7 +22,7 @@ log = logging.getLogger()
 class DataProduct(ABC):
     # TODO: Document this class properly
     description: str = ''
-    mission: Type[Mission]
+    mission: Missions
     id_suffix: str  # TODO: come up with a better name for this - it's used as a full id in the API so need to iron out the nomenclature
     instrument_ids: Set[str]
     processing_level: Union[str, None]

--- a/src/masschange/dataproducts/dataproduct.py
+++ b/src/masschange/dataproducts/dataproduct.py
@@ -62,7 +62,7 @@ class DataProduct(ABC):
 
         description = {
             'description': cls.description,
-            'mission': cls.mission.id,
+            'mission': cls.mission.asdict(),
             'id': cls.id_suffix,
             'full_id': cls.get_full_id(),
             'processing_level': cls.processing_level,

--- a/src/masschange/dataproducts/implementations/gracefo/events/problemfiles_evnt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/events/problemfiles_evnt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.events.problemfiles_evnt import GraceFOProblemFilesEventsDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOProblemFilesEventsDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOProblemFilesEventsDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'PROBLEMFILES_EVNT'
     instrument_ids = {'C', 'D'}
     processing_level = None  # Events does not have a processing level.

--- a/src/masschange/dataproducts/implementations/gracefo/events/soe_evnt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/events/soe_evnt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.events.soe_evnt import GraceFOSoeEventsDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOSoeEventsDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSoeEventsDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SOE_EVNT'
     instrument_ids = {'C', 'D'}
     processing_level = None  # Events does not have a processing level.

--- a/src/masschange/dataproducts/implementations/gracefo/events/spacecraft_evnt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/events/spacecraft_evnt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.events.spacecraft_evnt import GraceFOSpacecraftEventsDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOSpacecraftEventsDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSpacecraftEventsDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SPACECRAFT_EVNT'
     instrument_ids = {'C', 'D'}
     processing_level = None  # Events does not have a processing level.

--- a/src/masschange/dataproducts/implementations/gracefo/offred/offred.py
+++ b/src/masschange/dataproducts/implementations/gracefo/offred/offred.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.offred.offred import GraceFOOffredDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOOffredDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOOffredDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'OFFRED'
     instrument_ids = {'GF1', 'GF2'}
     # TODO: frequency is different per type of data. Need to figure out optimal common frequency

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/acc1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/acc1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.acc1a_pass import GraceFOAcc1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAcc1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAcc1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACC1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/ahk1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/ahk1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.ahk1a_pass import GraceFOAhk1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAhk1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAhk1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AHK1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/gnv1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/gnv1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.gnv1a_pass import GraceFOGnv1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGnv1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/gps1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/gps1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.gps1a_pass import GraceFOGps1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -13,7 +13,7 @@ class GraceFOGps1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGps1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPS1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/hrt1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/hrt1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.hrt1a_pass import GraceFOHrt1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOHrt1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOHrt1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'HRT1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/ihk1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/ihk1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.ihk1a_pass import GraceFOIhk1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOIhk1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIhk1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IHK1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/imu1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/imu1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.imu1a_pass import GraceFOImu1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOImu1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOImu1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IMU1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/kbr1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/kbr1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.kbr1a_pass import GraceFOKbr1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOKbr1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOKbr1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'KBR1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/lhk1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/lhk1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.lhk1a_pass import GraceFOLhk1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOLhk1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhk1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHK1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/lhm1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/lhm1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.lhm1a_pass import GraceFOLhm1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOLhm1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhm1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHM1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/lri1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/lri1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.lri1a_pass import GraceFOLri1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOLri1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLri1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LRI1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/lsm1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/lsm1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.lsm1a_pass import GraceFOLsm1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOLsm1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLsm1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LSM1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/mag1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/mag1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.mag1a_pass import GraceFOMag1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOMag1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMag1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAG1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/sca1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/sca1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.sca1a_pass import GraceFOSca1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOSca1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSca1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCA1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/thr1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/thr1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.thr1a_pass import GraceFOThr1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOThr1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOThr1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'THR1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/tim1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/tim1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.tim1a_pass import GraceFOTim1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOTim1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTim1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TIM1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/passreports/tnk1a_pass.py
+++ b/src/masschange/dataproducts/implementations/gracefo/passreports/tnk1a_pass.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.passreports.tnk1a_pass import GraceFOTnk1APassDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -12,7 +12,7 @@ class GraceFOTnk1APassDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTnk1APassDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TNK1A_PASS'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=3)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ac01a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ac01a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ac01a import GraceFOAc01ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAc01ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc01ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC01A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=100)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ac01b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ac01b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ac01b import GraceFOAc01BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAc01BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc01BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC01B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ac11a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ac11a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ac11a import GraceFOAc11ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAc11ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc11ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC11A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=100)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ac11b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ac11b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ac11b import GraceFOAc11BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAc11BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc11BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC11B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/acc1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/acc1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.acc1a import GraceFOAcc1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAcc1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAcc1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACC1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=100)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/act1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/act1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.act1a import GraceFOAct1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAct1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAct1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACT1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=100)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/act1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/act1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.act1b import GraceFOAct1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAct1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAct1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACT1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ahk1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ahk1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ahk1a import GraceFOAhk1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAhk1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAhk1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AHK1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ahk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ahk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ahk1b import GraceFOAhk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOAhk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAhk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AHK1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/clk1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/clk1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.clk1a import GraceFOClk1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOClk1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOClk1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'CLK1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/clk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/clk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.clk1b import GraceFOClk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOClk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOClk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'CLK1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gli1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gli1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gli1b import GraceFOGli1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOGli1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGli1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GLI1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/glv1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/glv1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.glv1b import GraceFOGlv1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOGlv1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGlv1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GLV1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gni1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gni1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gni1b import GraceFOGni1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -17,7 +17,7 @@ class GraceFOGni1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGni1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNI1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gnv1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gnv1a.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gnv1a import GraceFOGnv1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -11,7 +11,7 @@ class GraceFOGnv1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=2)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gnv1a_prn.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gnv1a_prn.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gnv1a_prn import GraceFOGnv1APrnDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGnv1APrnDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1APrnDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1A_PRN'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=2)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gnv1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gnv1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gnv1b import GraceFOGnv1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOGnv1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gps1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gps1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gps1a import GraceFOGps1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOGps1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGps1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPS1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/gps1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/gps1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.gps1b import GraceFOGps1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOGps1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGps1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPS1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/hrt1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/hrt1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.hrt1a import GraceFOHrt1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOHrt1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOHrt1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'HRT1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=32)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/hrt1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/hrt1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.hrt1b import GraceFOHrt1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOHrt1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOHrt1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'HRT1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=32)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ihk1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ihk1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ihk1a import GraceFOIhk1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOIhk1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIhk1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IHK1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=60)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ihk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ihk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ihk1b import GraceFOIhk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOIhk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIhk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IHK1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=60)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/ilg1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/ilg1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.ilg1a import GraceFOIlg1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 
 
@@ -14,7 +14,7 @@ class GraceFOIlg1ADataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIlg1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ILG1A'
     instrument_ids = {'C', 'D'}
     processing_level = '1A'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/imu1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/imu1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.imu1a import GraceFOImu1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOImu1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOImu1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IMU1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1/8) # 8Hz, three gyros

--- a/src/masschange/dataproducts/implementations/gracefo/primary/imu1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/imu1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.imu1b import GraceFOImu1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOImu1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOImu1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IMU1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1/8) # 8Hz, three gyros

--- a/src/masschange/dataproducts/implementations/gracefo/primary/kbr1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/kbr1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.kbr1a import GraceFOKbr1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOKbr1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOKbr1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'KBR1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=100)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/kbr1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/kbr1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.kbr1b import GraceFOKbr1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOKbr1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOKbr1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'KBR1B'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(seconds=5)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lhk1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lhk1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lhk1a import GraceFOLhk1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLhk1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhk1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHK1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lhk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lhk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lhk1b import GraceFOLhk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLhk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHK1B'
     instrument_ids = {'C', 'D'}
     # TODO: This is not a time-series dataset. It has data from many different sensors,

--- a/src/masschange/dataproducts/implementations/gracefo/primary/llg1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/llg1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.llg1a import GraceFOLlg1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 
 
@@ -14,7 +14,7 @@ class GraceFOLlg1ADataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlg1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLG1A'
     instrument_ids = {'C', 'D'}
     processing_level = '1A'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/llk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/llk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.llk1b import GraceFOLlk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLlk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLK1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/llt1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/llt1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.llt1a import GraceFOLlt1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLlt1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlt1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLT1A'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lri1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lri1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lri1a import GraceFOLri1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLri1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLri1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LRI1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1/10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lri1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lri1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lri1b import GraceFOLri1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLri1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLri1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LRI1B'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(seconds=2)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lsm1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lsm1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lsm1a import GraceFOLsm1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLsm1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLsm1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LSM1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1/10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/lsm1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/lsm1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.lsm1b import GraceFOLsm1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOLsm1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLsm1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LSM1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1/10)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/mag1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/mag1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.mag1a import GraceFOMag1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOMag1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMag1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAG1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=500)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/mag1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/mag1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.mag1b import GraceFOMag1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOMag1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMag1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAG1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=500)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/mas1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/mas1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.mas1a import GraceFOMas1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOMas1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMas1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAS1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/mas1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/mas1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.mas1b import GraceFOMas1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOMas1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMas1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAS1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(hours=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/pci1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/pci1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.pci1a import GraceFOPci1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOPci1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOPci1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'PCI1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=5)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/plt1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/plt1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.plt1a import GraceFOPlt1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOPlt1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOPlt1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'PLT1A'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/qcp1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/qcp1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.qcp1b import GraceFOQcp1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOQcp1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOQcp1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'QCP1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/qsa1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/qsa1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.qsa1b import GraceFOQsa1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOQsa1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOQsa1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'QSA1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/sca1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/sca1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.sca1a import GraceFOSca1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOSca1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSca1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCA1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(milliseconds=500)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/sca1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/sca1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.sca1b import GraceFOSca1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOSca1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSca1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCA1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tdp1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tdp1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tdp1a import GraceFOTdp1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOTdp1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTdp1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TDP1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tdp1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tdp1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tdp1b import GraceFOTdp1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 
 class GraceFOTdp1BDataProduct(TimeSeriesDataProduct):
@@ -10,7 +10,7 @@ class GraceFOTdp1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTdp1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TDP1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/thr1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/thr1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.thr1a import GraceFOThr1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -15,7 +15,7 @@ class GraceFOThr1ADataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOThr1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'THR1A'
     instrument_ids = {'C', 'D'}
     processing_level = '1A'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/thr1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/thr1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.thr1b import GraceFOThr1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -15,7 +15,7 @@ class GraceFOThr1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOThr1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'THR1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tim1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tim1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tim1a import GraceFOTim1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOTim1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTim1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TIM1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=8)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tim1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tim1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tim1b import GraceFOTim1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOTim1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTim1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TIM1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=8)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tnk1a.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tnk1a.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tnk1a import GraceFOTnk1ADataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOTnk1ADataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTnk1ADataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TNK1A'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)  # one measurement (but sometimes two) per tank per second.  Two tanks

--- a/src/masschange/dataproducts/implementations/gracefo/primary/tnk1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/tnk1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.tnk1b import GraceFOTnk1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOTnk1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTnk1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TNK1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(seconds=1)  # one measurement (but sometimes two) per tank per second.  Two tanks

--- a/src/masschange/dataproducts/implementations/gracefo/primary/uso1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/uso1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.uso1b import GraceFOUso1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesdataproduct import TimeSeriesDataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -12,7 +12,7 @@ class GraceFOUso1BDataProduct(TimeSeriesDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOUso1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'USO1B'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/primary/vgb1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/vgb1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.vgb1b import GraceFOVgb1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOVgb1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOVgb1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'VGB1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/vgn1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/vgn1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.vgn1b import GraceFOVgn1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOVgn1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOVgn1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'VGN1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/vgo1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/vgo1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.vgo1b import GraceFOVgo1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOVgo1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOVgo1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'VGO1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/vkb1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/vkb1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.vkb1b import GraceFOVkb1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOVkb1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOVkb1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'VKB1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/primary/vsl1b.py
+++ b/src/masschange/dataproducts/implementations/gracefo/primary/vsl1b.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.primary.vsl1b import GraceFOVsl1BDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.dataproduct import DataProduct
 from masschange.dataproducts.utils import get_schema_updates_for_flag_fields
 
@@ -13,7 +13,7 @@ class GraceFOVsl1BDataProduct(DataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOVsl1BDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'VSL1B'
     instrument_ids = {'C', 'D'}
     processing_level = '1B'

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ac01a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ac01a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ac01a_rpt import GraceFOAc01ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAc01ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc01ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC01A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ac01b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ac01b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ac01b_rpt import GraceFOAc01BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAc01BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc01BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC01B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ac11a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ac11a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ac11a_rpt import GraceFOAc11ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAc11ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc11ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC11A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ac11b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ac11b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ac11b_rpt import GraceFOAc11BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAc11BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAc11BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AC11B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/acc1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/acc1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.acc1a_rpt import GraceFOAcc1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAcc1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAcc1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACC1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/act1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/act1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.act1a_rpt import GraceFOAct1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAct1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAct1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACT1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/act1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/act1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.act1b_rpt import GraceFOAct1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAct1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAct1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ACT1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ahk1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ahk1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ahk1a_rpt import GraceFOAhk1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAhk1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAhk1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AHK1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ahk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ahk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ahk1b_rpt import GraceFOAhk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOAhk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOAhk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'AHK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/clk1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/clk1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.clk1a_rpt import GraceFOClk1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOClk1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOClk1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'CLK1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/clk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/clk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.clk1b_rpt import GraceFOClk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOClk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOClk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'CLK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gni1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gni1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gni1b_rpt import GraceFOGni1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGni1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGni1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNI1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gnv1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gnv1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gnv1a_rpt import GraceFOGnv1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGnv1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gnv1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gnv1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gnv1b_rpt import GraceFOGnv1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGnv1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGnv1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GNV1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gpi1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gpi1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gpi1a_rpt import GraceFOGpi1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGpi1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGpi1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPI1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gps1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gps1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gps1a_rpt import GraceFOGps1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGps1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGps1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPS1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/gps1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/gps1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.gps1b_rpt import GraceFOGps1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOGps1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOGps1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'GPS1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/hrt1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/hrt1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.hrt1a_rpt import GraceFOHrt1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOHrt1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOHrt1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'HRT1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ihk1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ihk1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ihk1a_rpt import GraceFOIhk1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOIhk1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIhk1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IHK1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ihk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ihk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ihk1b_rpt import GraceFOIhk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOIhk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIhk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IHK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/ilg1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/ilg1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.ilg1a_rpt import GraceFOIlg1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOIlg1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOIlg1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'ILG1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/imu1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/imu1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.imu1a_rpt import GraceFOImu1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOImu1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOImu1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IMU1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/imu1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/imu1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.imu1b_rpt import GraceFOImu1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOImu1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOImu1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'IMU1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/kbr1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/kbr1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.kbr1a_rpt import GraceFOKbr1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOKbr1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOKbr1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'KBR1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/kbr1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/kbr1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.kbr1b_rpt import GraceFOKbr1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOKbr1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOKbr1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'KBR1B_RPT'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lhk1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lhk1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lhk1a_rpt import GraceFOLhk1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLhk1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhk1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHK1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lhk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lhk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lhk1b_rpt import GraceFOLhk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLhk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLhk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LHK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/llg1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/llg1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.llg1a_rpt import GraceFOLlg1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLlg1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlg1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLG1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/llk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/llk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.llk1b_rpt import GraceFOLlk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLlk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/llt1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/llt1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.llt1a_rpt import GraceFOLlt1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLlt1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLlt1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LLT1A_RPT'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lri1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lri1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lri1a_rpt import GraceFOLri1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLri1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLri1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LRI1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lri1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lri1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lri1b_rpt import GraceFOLri1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLri1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLri1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LRI1B_RPT'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lsm1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lsm1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lsm1a_rpt import GraceFOLsm1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLsm1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLsm1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LSM1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/lsm1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/lsm1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.lsm1b_rpt import GraceFOLsm1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOLsm1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOLsm1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'LSM1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/mag1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/mag1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.mag1a_rpt import GraceFOMag1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOMag1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMag1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAG1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/mag1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/mag1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.mag1b_rpt import GraceFOMag1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOMag1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMag1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAG1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/mas1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/mas1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.mas1a_rpt import GraceFOMas1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOMas1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMas1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAS1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/mas1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/mas1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.mas1b_rpt import GraceFOMas1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOMas1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOMas1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'MAS1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/pci1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/pci1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.pci1a_rpt import GraceFOPci1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOPci1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOPci1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'PCI1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/plt1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/plt1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.plt1a_rpt import GraceFOPlt1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOPlt1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOPlt1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'PLT1A_RPT'
     instrument_ids = {'Y'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/poe1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/poe1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.poe1a_rpt import GraceFOPoe1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOPoe1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOPoe1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'POE1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/sca1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/sca1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.sca1a_rpt import GraceFOSca1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOSca1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSca1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCA1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/sca1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/sca1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.sca1b_rpt import GraceFOSca1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOSca1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSca1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCA1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/sci1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/sci1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.sci1a_rpt import GraceFOSci1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOSci1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOSci1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'SCI1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/thr1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/thr1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.thr1a_rpt import GraceFOThr1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOThr1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOThr1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'THR1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/thr1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/thr1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.thr1b_rpt import GraceFOThr1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOThr1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOThr1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'THR1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/tim1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/tim1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.tim1a_rpt import GraceFOTim1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOTim1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTim1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TIM1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/tim1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/tim1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.tim1b_rpt import GraceFOTim1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOTim1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTim1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TIM1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/tnk1a_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/tnk1a_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.tnk1a_rpt import GraceFOTnk1ARptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOTnk1ARptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTnk1ARptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TNK1A_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/tnk1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/tnk1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.tnk1b_rpt import GraceFOTnk1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOTnk1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOTnk1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'TNK1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/dataproducts/implementations/gracefo/rpt/uso1b_rpt.py
+++ b/src/masschange/dataproducts/implementations/gracefo/rpt/uso1b_rpt.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from masschange.ingest.executor.datafilereaders.base import DataFileReader
 from masschange.ingest.executor.datafilereaders.gracefo.rpt.uso1b_rpt import GraceFOUso1BRptDataFileReader
-from masschange.missions import GraceFO
+from masschange.missions import Missions
 from masschange.dataproducts.timeseriesrptdataproduct import TimeSeriesRptDataProduct
 
 
@@ -11,7 +11,7 @@ class GraceFOUso1BRptDataProduct(TimeSeriesRptDataProduct):
     def get_reader(cls) -> DataFileReader:
         return GraceFOUso1BRptDataFileReader()
 
-    mission = GraceFO
+    mission = Missions.GraceFO
     id_suffix = 'USO1B_RPT'
     instrument_ids = {'C', 'D'}
     time_series_interval = timedelta(days=1)

--- a/src/masschange/missions/__init__.py
+++ b/src/masschange/missions/__init__.py
@@ -1,6 +1,8 @@
 class Mission:
     """Contains basic mission-wide configuration used by member datasets"""
     id: str
+    label: str
 
 class GraceFO(Mission):
     id = 'GRACEFO'
+    label = 'GRACE-FO'

--- a/src/masschange/missions/__init__.py
+++ b/src/masschange/missions/__init__.py
@@ -1,8 +1,23 @@
+from dataclasses import dataclass, asdict
+from enum import Enum
+
+from typing_extensions import Callable
+
+
+@dataclass(frozen=True)
 class Mission:
     """Contains basic mission-wide configuration used by member datasets"""
     id: str
     label: str
 
-class GraceFO(Mission):
-    id = 'GRACEFO'
-    label = 'GRACE-FO'
+    def asdict(self):
+        return asdict(self)
+
+
+class Missions(Enum):
+    GraceFO = Mission(id='GRACEFO', label='GRACE-FO')
+
+    def __init__(self, item):
+        self.id = item.id
+        self.label = item.label
+        self.asdict: Callable = item.asdict


### PR DESCRIPTION
- Reimplements `Mission` as a rich-object Enum
- Implements `Mission.label`at request of @marjo-luc 
- Breaks compatibility with web-ui consumption of the `mission` attribute - references to `mission` must be replaced with `mission.id` or `mission.label` as appropriate @marjo-luc @AaronPlave 

@IrinaTkatcheva N.B. the only files which merit review are the first two, and the last one - everything else is just an update from references to old class `GraceFO` to references to `Missions.GraceFO`