### PR TITLE
Fix #245: Throw error for non-aggregable fields during downsampling

### DIFF
--- a/src/masschange/api/routers/datasets.py
+++ b/src/masschange/api/routers/datasets.py
@@ -144,23 +144,33 @@ def _get_results_with_metadata(product, from_isotimestamp, to_isotimestamp, resu
 def _get_fields(dataset, field_names, downsampling_factor):
     fields = set()
     dataset_fields_by_name = {field.name: field for field in dataset.product.get_available_fields()}
+    using_aggregations = dataset.is_time_series_dataset() and downsampling_factor > 1
+    
+    # Track fields that are invalid for aggregation
+    invalid_fields_for_aggregation = []
 
     for field_name in field_names:
         try:
             field = dataset_fields_by_name[field_name]
             if dataset.is_time_series_dataset():
-                using_aggregations = downsampling_factor > 1
-
-                # when downsampling, only pick valid aggregable fields
-                # silently dropping non-aggregable fields isn't ideal, but the alternative is to lose the API default
-                # fields value, which would be a loss since it significantly improves the docs
-                if not using_aggregations or field.has_aggregations or field.is_lookup_field:
+                # when downsampling, validate that fields are aggregable
+                if using_aggregations and not field.has_aggregations and not field.is_lookup_field:
+                    invalid_fields_for_aggregation.append(field_name)
+                else:
                     fields.add(field)
             else:
                 fields.add(field)
         except KeyError:
             raise HTTPException(status_code=400,
-                                detail=f'Field "{field_name}" not defined for dataset {product.get_full_id()} (expected one of {sorted([f.name for f in product.get_available_fields()])})')
+                                detail=f'Field "{field_name}" not defined for dataset {dataset.product.get_full_id()} (expected one of {sorted([f.name for f in dataset.product.get_available_fields()])})')
+
+    # If there are invalid fields for aggregation, throw an error
+    if invalid_fields_for_aggregation:
+        available_aggregable_fields = sorted([f.name for f in dataset.product.get_available_fields() 
+                                            if f.has_aggregations or f.is_lookup_field or f.name == dataset.product.TIMESTAMP_COLUMN_NAME])
+        raise HTTPException(status_code=400,
+                           detail=f'Fields {invalid_fields_for_aggregation} are not aggregable and cannot be requested when downsampling is required. '
+                                 f'Available aggregable fields: {available_aggregable_fields}')
 
     #  ensure that timestamp column name is always present in query
     fields.add(dataset_fields_by_name[dataset.product.TIMESTAMP_COLUMN_NAME])

--- a/src/masschange/api/routers/datasets.py
+++ b/src/masschange/api/routers/datasets.py
@@ -154,7 +154,7 @@ def _get_fields(dataset, field_names, downsampling_factor):
             field = dataset_fields_by_name[field_name]
             if dataset.is_time_series_dataset():
                 # when downsampling, validate that fields are aggregable
-                if using_aggregations and not field.has_aggregations and not field.is_lookup_field:
+                if using_aggregations and not field.has_aggregations and not field.is_lookup_field and not field.name == dataset.product.TIMESTAMP_COLUMN_NAME:
                     invalid_fields_for_aggregation.append(field_name)
                 else:
                     fields.add(field)

--- a/src/masschange/api/tests/test_api_ops.py
+++ b/src/masschange/api/tests/test_api_ops.py
@@ -270,3 +270,59 @@ def test_statistics_basic():
         path = f'{base_path}/{statistic.value}'
         response = client.get(path)
         assert response.status_code == 200
+
+
+def test_non_aggregable_fields_error_during_downsampling():
+    """Test that non-aggregable fields throw an error when downsampling is required"""
+    product = GraceFOAcc1ADataProduct()
+    dataset = TimeSeriesDataset(product, DatasetVersion('04'), 'C')
+    dataset_data_span = dataset.get_data_span()
+    
+    assert dataset_data_span is not None
+    
+    # Use a large time span that will trigger automatic downsampling
+    test_span_begin = dataset_data_span.begin
+    test_span_end = test_span_begin + timedelta(days=8)  # Large span to force downsampling
+    
+    # Request a non-aggregable field (rcvtime_intg) along with timestamp
+    # This should trigger the error from the GitHub issue
+    path = f'/missions/{product.mission.id}/products/{product.id_suffix}/versions/04/instruments/C/data?' \
+           f'from_isotimestamp={test_span_begin.isoformat()}&to_isotimestamp={test_span_end.isoformat()}' \
+           f'&fields=timestamp&fields=rcvtime_intg'
+    
+    response = client.get(path)
+    
+    # Should return 400 Bad Request with a descriptive error message
+    assert response.status_code == 400
+    content = response.json()
+    assert 'detail' in content
+    assert 'rcvtime_intg' in content['detail']
+    assert 'not aggregable' in content['detail']
+    assert 'Available aggregable fields' in content['detail']
+
+
+def test_aggregable_fields_work_during_downsampling():
+    """Test that aggregable fields work correctly when downsampling is required"""
+    product = GraceFOAcc1ADataProduct()
+    dataset = TimeSeriesDataset(product, DatasetVersion('04'), 'C')
+    dataset_data_span = dataset.get_data_span()
+    
+    assert dataset_data_span is not None
+    
+    # Use a large time span that will trigger automatic downsampling
+    test_span_begin = dataset_data_span.begin
+    test_span_end = test_span_begin + timedelta(days=8)  # Large span to force downsampling
+    
+    # Request only aggregable fields (timestamp and lin_accl_x)
+    path = f'/missions/{product.mission.id}/products/{product.id_suffix}/versions/04/instruments/C/data?' \
+           f'from_isotimestamp={test_span_begin.isoformat()}&to_isotimestamp={test_span_end.isoformat()}' \
+           f'&fields=timestamp&fields=lin_accl_x'
+    
+    response = client.get(path)
+    
+    # Should return 200 OK since all requested fields are aggregable
+    assert response.status_code == 200
+    content = response.json()
+    assert 'data' in content
+    assert 'downsampling_factor' in content
+    assert content['downsampling_factor'] > 1  # Verify downsampling occurred


### PR DESCRIPTION
- Fix silent dropping of `non-aggregable` fields when downsampling is required
- Replace silent field exclusion with descriptive `HTTP 400 error`
- Add comprehensive error message listing available aggregable fields
- Maintain backward compatibility for non-downsampling scenarios

Changes:
- Modified `_get_fields()` in `datasets.py` to validate field aggregability
- Added test cases to verify error handling and aggregable field behavior
- Improved `API error `messages for better developer experience

Resolves issue #245  where `rcvtime_intg` and other `non-aggregable` fields were silently omitted from responses instead of throwing appropriate errors when automatic downsampling was triggered by large time spans.

Closes: #245 