### PR TITLE
Handle a case GraceFOGnv1ADataProduct does not have a version equal a…

### DIFF
--- a/src/masschange/api/tests/test_api_ops.py
+++ b/src/masschange/api/tests/test_api_ops.py
@@ -10,6 +10,7 @@ from masschange.api.routers.datasets import SupportedStatisticsEnum
 from masschange.api.tests.utils import is_nearly_equal, permute_all_datasets
 from masschange.dataproducts.implementations.gracefo.primary.acc1a import GraceFOAcc1ADataProduct
 from masschange.dataproducts.implementations.gracefo.primary.gnv1a import GraceFOGnv1ADataProduct
+from masschange.dataproducts.implementations.gracefo.primary.icsnr import GraceFOIcsnrDataProduct
 from masschange.dataproducts.timeseriesdataset import TimeSeriesDataset
 from masschange.dataproducts.dataset import Dataset
 from masschange.dataproducts.datasetversion import DatasetVersion
@@ -209,6 +210,57 @@ def test_downsampled_location_lookup():
     assert full_res_min_latitude <= downsampled_datum['location']['latitude'] <= full_res_max_latitude
     assert full_res_min_longitude <= downsampled_datum['location']['longitude'] <= full_res_max_longitude
 
+def test_downsampled_location_lookup_versions_missmatch():
+    # Test for a case when matching version ov GNV1A data is not available
+    product = GraceFOIcsnrDataProduct()
+    dataset = TimeSeriesDataset(product, DatasetVersion('00'), 'C')
+    dataset_data_span = dataset.get_data_span()
+
+    gnv_dataset = TimeSeriesDataset(GraceFOGnv1ADataProduct(), DatasetVersion('04'), 'C')
+    gnv_data_span = gnv_dataset.get_data_span()
+
+    assert dataset_data_span is not None
+    assert gnv_data_span is not None
+
+    test_span_begin = max(dataset_data_span.begin, gnv_data_span.begin)
+    test_span_end = test_span_begin + timedelta(minutes=2)
+    dt_format = '%Y-%m-%dT%H:%M:%S'
+
+    full_res_path = f'/missions/{dataset.product.mission.id}/products/{dataset.product.id_suffix}\
+/versions/{dataset.version}/instruments/{dataset.instrument_id}/data?\
+from_isotimestamp={test_span_begin.strftime(dt_format)}&to_isotimestamp={test_span_end.strftime(dt_format)}&fields=location'
+    full_res_response = client.get(full_res_path)
+
+    assert full_res_response.status_code == 200
+    full_res_content = full_res_response.json()
+
+    downsampling_factor = dataset.product.get_available_downsampling_factors()[2]
+    downsampled_path = f'/missions/{dataset.product.mission.id}/products/{dataset.product.id_suffix}\
+/versions/{dataset.version}/instruments/{dataset.instrument_id}/data?\
+from_isotimestamp={test_span_begin.strftime(dt_format)}&to_isotimestamp={test_span_end.strftime(dt_format)}\
+&fields=location&downsampling_factor={downsampling_factor}'
+    downsampled_response = client.get(downsampled_path)
+    assert downsampled_response.status_code == 200
+    downsampled_content = downsampled_response.json()
+
+    downsampled_datum = downsampled_content['data'][1]
+
+    # Timestamp for a bucket is at the beginning of the bucket. Check that the downsampling location is withing bounding
+    # box of full resolution data centered at the time of the downsampled data point, plus/minus the
+    # product.time_series_interval
+    bounding_box_start = datetime.fromisoformat(downsampled_datum['timestamp']) - product.time_series_interval
+    bounding_box_end = datetime.fromisoformat(downsampled_datum['timestamp']) + product.time_series_interval
+
+    full_res_data = [d for d in full_res_content['data'] if
+                     bounding_box_start <= datetime.fromisoformat(d['timestamp']) < bounding_box_end]
+
+    full_res_min_latitude = min(d['location']['latitude'] for d in full_res_data)
+    full_res_max_latitude = max(d['location']['latitude'] for d in full_res_data)
+    full_res_min_longitude = min(d['location']['longitude'] for d in full_res_data)
+    full_res_max_longitude = max(d['location']['longitude'] for d in full_res_data)
+
+    assert full_res_min_latitude <= downsampled_datum['location']['latitude'] <= full_res_max_latitude
+    assert full_res_min_longitude <= downsampled_datum['location']['longitude'] <= full_res_max_longitude
 
 def test_product_metadata_basic():
     path = f'/missions/GRACEFO/products/'

--- a/src/masschange/dataproducts/dataset.py
+++ b/src/masschange/dataproducts/dataset.py
@@ -277,10 +277,35 @@ class Dataset:
         The maximal error will be equal to +/- the satellite's movement in one second (i.e. half the temporal resolution
         of the GNV dataset).
         TODO: N.B. this may only hold true for timespans where downsampling of the GNV is not required - need to confirm
+        For downsampling data, the location assigned at a time of the start of the bucket.
+        The buckets are aligned in an orderly fashion according to the bucket size, relative to some epoch, which
+        is a single system-wide value. So the bucket will almost invariable start some period of time prior to the first
+        datum. The time delta could be up to product.time_series_interval. For low-frequency datasets the time delta
+        could lead to a noticeable error in bucket's geolocation.
+
         A value of None will be assigned to input data for which there is no GNV data available.
         """
 
-        gnv_dataset: Dataset = DatasetFactory.create(GraceFOGnv1ADataProduct(), self.version, self.instrument_id)
+        # If GraceFOGnv1ADataProduct does not have a version equal the current product's version,
+        # try use version '00' (per recommendation from Chris). If '00' is not available, use the
+        # latest available GNV1A version
+        gnv_available_versions_values = GraceFOGnv1ADataProduct.describe()['available_versions']
+        if self.version.value not in gnv_available_versions_values:
+            if '00' in gnv_available_versions_values:
+                gnv_version = DatasetVersion('00')
+                logging.warning(
+                    f'Version {self.version.value} of GNV1A is not available. Falling back to version "00" for geolocation')
+            else:
+                gnv_available_versions_values.sort()
+                gnv_version = DatasetVersion(gnv_available_versions_values[-1])
+                logging.warning(
+                    f'Version {self.version.value} of GNV1A is not available. Using the latest version '
+                    f'{gnv_version.value} for geolocation')
+        else:
+            gnv_version = self.version
+
+        gnv_dataset: Dataset = DatasetFactory.create(GraceFOGnv1ADataProduct(), gnv_version, self.instrument_id)
+
         gnv_field_names = {gnv_dataset.product.TIMESTAMP_COLUMN_NAME, 'location'}
         gnv_fields = [f for f in gnv_dataset.product.get_available_fields() if f.name in gnv_field_names]
 

--- a/src/masschange/ingest/executor/datafilereaders/base_offred.py
+++ b/src/masschange/ingest/executor/datafilereaders/base_offred.py
@@ -295,5 +295,5 @@ class OffredFileReader(AsciiDataFileReader):
     @classmethod
     def extract_dataset_version(cls, filepath: str) -> DatasetVersion:
         # no versions for OFFREAD
-        return DatasetVersion("01")
+        return DatasetVersion("00")
 

--- a/tests/ingest/datasets/gracefo/offred/test_offred.py
+++ b/tests/ingest/datasets/gracefo/offred/test_offred.py
@@ -34,7 +34,7 @@ class GraceFOOffredDatasetReaderTestCase(DatasetReaderTestCaseBase):
     data_is_zipped = False
     maxDiff = None
     dataset_cls = StubGraceFOOffredDataProduct
-    expected_table_names = ['gracefo_offred_01_gf1', 'gracefo_offred_01_gf2']
+    expected_table_names = ['gracefo_offred_00_gf1', 'gracefo_offred_00_gf2']
     expected_field_types = [str, int, int, str, str, str, Union[str, None], Union[int, None], Union[float, None],
                             Union[str, None], datetime]
     expected_table_row_counts = [42, 42]

--- a/tests/ingest/test_ingest_delete_overlaps_by_source_fname.py
+++ b/tests/ingest/test_ingest_delete_overlaps_by_source_fname.py
@@ -30,7 +30,7 @@ class DataOverwriteByFileNameIngestTestCase(IngestTestCaseBase):
     data_file2 = './tests/input_data/GF1_CX_888888_XXX_7_777777777_7777_77777777777_77777777777.out'
     expected_record_count = 84 # 6 lines, 7 variables, 2 files
     def setUp(self):
-        self.dataset = DatasetFactory.create(self.product, DatasetVersion('01'), 'GF1' )
+        self.dataset = DatasetFactory.create(self.product, DatasetVersion('00'), 'GF1' )
         os.environ['OFFREAD_METADATA_FILE'] = './tests/input_data/offred/fake_fields_metadata.json'
         super().__init__()
 


### PR DESCRIPTION
Updated to geolocation:
If GNV1A dataset does not have the same version as a dataset to be geolocated, use version of '00' of GNV1A data. If '00' id not available, use a latest available version