### PR TITLE
283-set-aggregation-for-double-variables-in-resids-tdp1a-tdp1b-datasets

### DIFF
--- a/src/masschange/ingest/executor/datafilereaders/gracefo/primary/resids.py
+++ b/src/masschange/ingest/executor/datafilereaders/gracefo/primary/resids.py
@@ -29,7 +29,8 @@ class GraceFOResidsDataFileReader(AsciiDataFileReader):
     def get_input_column_defs(cls) -> Collection[AsciiDataFileReaderColumn]:
         return [
             AsciiDataFileReaderColumn(index=0, name='time', np_type=np.ulonglong, unit='s'),
-            AsciiDataFileReaderColumn(index=1, name='kbr_gps_residual', np_type=np.double, unit='cm')
+            AsciiDataFileReaderColumn(index=1, name='kbr_gps_residual', np_type=np.double, unit='cm',
+                                      aggregations=['min', 'max'])
         ]
 
     @classmethod

--- a/src/masschange/ingest/executor/datafilereaders/gracefo/primary/tdp1a.py
+++ b/src/masschange/ingest/executor/datafilereaders/gracefo/primary/tdp1a.py
@@ -42,8 +42,10 @@ class GraceFOTdp1ADataFileReader(AsciiDataFileReader):
         return [
             AsciiDataFileReaderColumn(index=0, name='time', np_type=np.ulonglong, unit='s'),
             AsciiDataFileReaderColumn(index=1, name='nominal_value', np_type=np.double, unit='None'),
-            AsciiDataFileReaderColumn(index=2, name='value', np_type=np.double, unit='None'),
-            AsciiDataFileReaderColumn(index=3, name='sigma', np_type=np.double, unit='None'),
+            AsciiDataFileReaderColumn(index=2, name='value', np_type=np.double, unit='None',
+                                      aggregations=['min', 'max']),
+            AsciiDataFileReaderColumn(index=3, name='sigma', np_type=np.double, unit='None',
+                                      aggregations=['min', 'max']),
             AsciiDataFileReaderColumn(index=4, name='name', np_type='U512', unit=None, is_channel_id_column=True)
         ]
 

--- a/src/masschange/ingest/executor/datafilereaders/gracefo/primary/tdp1b.py
+++ b/src/masschange/ingest/executor/datafilereaders/gracefo/primary/tdp1b.py
@@ -42,8 +42,10 @@ class GraceFOTdp1BDataFileReader(AsciiDataFileReader):
         return [
             AsciiDataFileReaderColumn(index=0, name='time', np_type=np.ulonglong, unit='s'),
             AsciiDataFileReaderColumn(index=1, name='nominal_value', np_type=np.double, unit='None'),
-            AsciiDataFileReaderColumn(index=2, name='value', np_type=np.double, unit='None'),
-            AsciiDataFileReaderColumn(index=3, name='sigma', np_type=np.double, unit='None'),
+            AsciiDataFileReaderColumn(index=2, name='value', np_type=np.double, unit='None',
+                                      aggregations=['min', 'max']),
+            AsciiDataFileReaderColumn(index=3, name='sigma', np_type=np.double, unit='None',
+                                      aggregations=['min', 'max']),
             AsciiDataFileReaderColumn(index=4, name='name', np_type='U512', unit=None, is_channel_id_column=True)
         ]
 


### PR DESCRIPTION
Add aggregation type for variables of type 'double' in RESIDS, TDP1A, TDP1B datasets