### PR TITLE
fix to PR 303

### DIFF
--- a/src/masschange/db/ingestmanagement/ensure.py
+++ b/src/masschange/db/ingestmanagement/ensure.py
@@ -43,11 +43,11 @@ def ensure_ingest_manager_tables_exist() -> None:
             -- partitions prevent active-job query performance from degrading as completed jobs pile up
             CREATE TABLE _ingestmgr_crawled_files_active
             PARTITION OF _ingestmgr_crawled_files
-            FOR VALUES IN ('CRAWLED', 'STAGED', 'INGEST_STARTED', 'INGEST_TERMINATED');
+            FOR VALUES IN ('CRAWLED', 'STAGED', 'INGEST_STARTED', 'INGEST_TERMINATED', 'REJECTED');
         
-            CREATE TABLE _ingestmgr_crawled_files_done
+            CREATE TABLE _ingestmgr_crawled_files_completed
             PARTITION OF _ingestmgr_crawled_files
-            FOR VALUES IN ('INGEST_SUCCESS', 'REJECTED');
+            FOR VALUES IN ('INGEST_SUCCESS');
             
             -- sparse partial indices for common query patterns
             CREATE INDEX idx_ready_jobs


### PR DESCRIPTION
 move REJECTED jobs back to the active partition, as this only refers to invalid (zero-byte) files