### PR TITLE
ModuleNotFoundError is now logged as ERROR 

### DIFF
--- a/src/masschange/utils/packaging.py
+++ b/src/masschange/utils/packaging.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import pkgutil
 
 
@@ -16,7 +17,8 @@ def import_submodules(package, recursive=True):
         full_name = package.__name__ + '.' + name
         try:
             results[full_name] = importlib.import_module(full_name)
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as err:
+            logging.error(f'Failed to import module {full_name} from {package.__name__} due to {err}')
             continue
         if recursive and is_pkg:
             results.update(import_submodules(full_name))


### PR DESCRIPTION
rather than being silently caught.

This was obscuring legitimate `ModuleNotFoundError` instances thrown due to failure to force no-cache rebuild of image following the addition of a python dependency, when deploying the updated code.

It's unclear what instances it was intended to silently catch in the first place, so all are instead logged as ERROR until there's a reason to do otherwise.